### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+flask-cors
+google-genai


### PR DESCRIPTION
I added requirements.txt, which is a file containing the required python extensions. This file is used when installing this extensions on the terminal. 